### PR TITLE
Split and rename examples

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           mkdir pages
           cd pages
-          ../website/render_activities.py --no-individual-pages --exclude "*template*" ../activities/config.json ../nc_spm_08_grass7/user1
+          ../website/render_activities.py --no-individual-pages --exclude "*example*" ../activities/config.json ../nc_spm_08_grass7/user1
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Generated web pages
+pages

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ and a local repository on your computer
 
 ### Develop new analysis
 
-1. Create a new Python script according to the template.
-   - There is a template called `activity_template.py` in the `activities` directory
+1. Create a new Python script according to the provided example.
+   - There is an example called `simple_example.py` in the `activities` directory
      which gives information about the specific conventions.
-   - Use a unique filename, for example use your name (e.g., `petras_activity.py`).
+   - Use a unique filename, for example use your name (e.g., `petras.py`).
    - You can use the Simple Python Editor in GRASS GIS
      which will make it simple to executed Python code in GRASS GIS
      without additional setup.
@@ -34,12 +34,15 @@ and a local repository on your computer
 
 ### Configure an activity
 
-1. Create a new JSON configuration file according to the template.
-   - There is a template called `config_template.json` in the `activities` directory
+1. Create a new JSON configuration file according to the provided example.
+   - There is an example called `simple_example.json` in the `activities` directory
      which provides an example of a minimal activity configuration.
-   - Again, use a unique filename, for example use your name (e.g., `petras_config.json`).
+   - Again, use a unique filename, for example use your name (e.g., `petras.json`).
 1. Set value for the `analyses` key to the filename of your Python script.
 1. Change `title` of the task and modify `layers` to fit your needs.
+
+Note that the name of the JSON configuration file differs from the name of the
+Python file only by extension (`.json` versus `.py`).
 
 ### Create a pull request
 

--- a/activities/advanced_example.json
+++ b/activities/advanced_example.json
@@ -2,7 +2,14 @@
   "tasks": [
     {
       "layers": [
-        ["d.vect", "map=points", "color=77:77:77", "icon=basic/marker"]
+        [
+          "d.vect",
+          "map=points",
+          "icon=basic/pin",
+          "size=10",
+          "color=#00284E",
+          "fill_color=#00509E"
+        ]
       ],
       "base": "elev_lid792_1m",
       "scanning_params": {

--- a/activities/advanced_example.json
+++ b/activities/advanced_example.json
@@ -2,8 +2,7 @@
   "tasks": [
     {
       "layers": [
-        ["d.rast", "map=slope"],
-        ["d.vect", "map=contours", "color=77:77:77", "width=2"]
+        ["d.vect", "map=points", "color=77:77:77", "icon=basic/marker"]
       ],
       "base": "elev_lid792_1m",
       "scanning_params": {
@@ -13,8 +12,8 @@
         "interpolate": true
       },
       "calibrate": true,
-      "analyses": "activity_template.py",
-      "title": "Slope and contours"
+      "analyses": "advanced_example.py",
+      "title": "Load and Display Points"
     }
   ]
 }

--- a/activities/advanced_example.py
+++ b/activities/advanced_example.py
@@ -4,38 +4,32 @@
 Instructions
 
 - Functions intended to run for each scan
-  need to be named run_xxxxx
+  need to start with `run_`, e.g., `run_slope`.
 
-- Do not modify the parameters of the run_xxx function
-  unless you know what you are doing
-  see optional parameters:
+- Do not modify the parameters of the `run_` function
+  unless you know what you are doing.
+  See optional parameters at:
   https://github.com/tangible-landscape/grass-tangible-landscape/wiki/Running-analyses-and-developing-workflows#python-workflows
 
 - All gs.run_command/read_command/write_command/parse_command
-  need to be passed env parameter (..., env=env)
+  need to be passed *env* parameter like this: `(..., env=env)`.
 """
+
+import os
 
 import grass.script as gs
 
 
-def run_slope(scanned_elev, env, **kwargs):
-    gs.run_command("r.slope.aspect", elevation=scanned_elev, slope="slope", env=env)
-
-
-def run_contours(scanned_elev, env, **kwargs):
-    interval = 5
-    gs.run_command(
-        "r.contour",
-        input=scanned_elev,
-        output="contours",
-        step=interval,
-        flags="t",
-        env=env,
-    )
-
-
 def run_function_with_points(scanned_elev, env, points=None, **kwargs):
+    """Doesn't do anything, except loading points from a vector map to Python
+
+    If *points* is provided, the function assumes it is name of an existing vector map.
+    This is used during testing.
+    If *points* is not provided, the function assumes it runs in Tangible Landscape.
+    """
     if not points:
+        # If there are no points, ask Tangible Landscape to generate points from
+        # a change in the surface.
         points = "points"
         import analyses
 
@@ -50,7 +44,7 @@ def run_function_with_points(scanned_elev, env, points=None, **kwargs):
             debug=True,
             env=env,
         )
-    # read coordinates into a list
+    # Output point coordinates from GRASS GIS and read coordinates into a Python list.
     point_list = []
     data = (
         gs.read_command(
@@ -68,26 +62,23 @@ def run_function_with_points(scanned_elev, env, points=None, **kwargs):
         point_list.append([float(p) for p in point.split(",")])
 
 
-# this part is for testing without TL
 def main():
-    import os
+    """Function which runs when testing without Tangible Landscape"""
 
-    # get the current environment variables as a copy
+    # No need to edit this block. It should stay the same.
+    # Get the current environment variables as a copy.
     env = os.environ.copy()
-    # we want to run this repetitively without deleted the created files
+    # We want to run this repetitively and replace the old data by the new data.
     env["GRASS_OVERWRITE"] = "1"
-
     elevation = "elev_lid792_1m"
     elev_resampled = "elev_resampled"
-    # resampling to have similar resolution as with TL
+    # We use resampling to get a similar resolution as with Tangible Landscape.
     gs.run_command("g.region", raster=elevation, res=4, flags="a", env=env)
     gs.run_command("r.resamp.stats", input=elevation, output=elev_resampled, env=env)
+    # The end of the block which needs no editing.
 
-    # this will run all 3 examples (slope, contours, points)
-    run_slope(scanned_elev=elev_resampled, env=env)
-    run_contours(scanned_elev=elev_resampled, env=env)
-
-    # create points
+    # Code specific to testing of the analytical function.
+    # Create points which is the additional input needed for the process.
     points = "points"
     gs.write_command(
         "v.in.ascii",
@@ -98,6 +89,7 @@ def main():
         stdin="638432,220382\n638621,220607",
         env=env,
     )
+    # Call the analysis.
     run_function_with_points(scanned_elev=elev_resampled, env=env, points=points)
 
 

--- a/activities/simple_example.json
+++ b/activities/simple_example.json
@@ -1,10 +1,9 @@
 {
-  "includeTasks": ".",
   "tasks": [
     {
       "layers": [
         ["d.rast", "map=slope"],
-        ["d.vect", "map=contours"]
+        ["d.vect", "map=contours", "color=77:77:77", "width=2"]
       ],
       "base": "elev_lid792_1m",
       "scanning_params": {
@@ -13,9 +12,8 @@
         "numscans": 1,
         "interpolate": true
       },
-      "calibrate": true,
-      "analyses": "simple_example.json",
-      "title": "Template"
+      "analyses": "simple_example.py",
+      "title": "Slope and contours"
     }
   ]
 }

--- a/activities/simple_example.py
+++ b/activities/simple_example.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+"""
+Instructions
+
+- Functions intended to run for each scan
+  need to start with `run_`, e.g., `run_slope`.
+
+- Do not modify the parameters of the `run_` function
+  unless you know what you are doing.
+  See optional parameters at:
+  https://github.com/tangible-landscape/grass-tangible-landscape/wiki/Running-analyses-and-developing-workflows#python-workflows
+
+- All gs.run_command/read_command/write_command/parse_command
+  need to be passed *env* parameter like this: `(..., env=env)`.
+"""
+
+import os
+
+import grass.script as gs
+
+# Edit here:
+# The following functions starting with the word run follwed by an underscore
+# are the analysis which will run on Tangible Landscape (and during testing).
+
+
+def run_slope(scanned_elev, env, **kwargs):
+    gs.run_command("r.slope.aspect", elevation=scanned_elev, slope="slope", env=env)
+
+
+def run_contours(scanned_elev, env, **kwargs):
+    interval = 5
+    gs.run_command(
+        "r.contour",
+        input=scanned_elev,
+        output="contours",
+        step=interval,
+        flags="t",
+        env=env,
+    )
+
+
+def main():
+    """Function which runs when testing without Tangible Landscape"""
+
+    # No need to edit this block. It should stay the same.
+    # Get the current environment variables as a copy.
+    env = os.environ.copy()
+    # We want to run this repetitively and replace the old data by the new data.
+    env["GRASS_OVERWRITE"] = "1"
+    elevation = "elev_lid792_1m"
+    elev_resampled = "elev_resampled"
+    # We use resampling to get a similar resolution as with Tangible Landscape.
+    gs.run_command("g.region", raster=elevation, res=4, flags="a", env=env)
+    gs.run_command("r.resamp.stats", input=elevation, output=elev_resampled, env=env)
+    # The end of the block which needs no editing.
+
+    # Edit here:
+    # Place your function call or calls here.
+    # This will run both examples (slope and contours).
+    run_slope(scanned_elev=elev_resampled, env=env)
+    run_contours(scanned_elev=elev_resampled, env=env)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/filenames.py
+++ b/tests/filenames.py
@@ -11,10 +11,10 @@ class TestFunctionsInFiles(unittest.TestCase):
 
     path = "activities/"
     allow_files = [
-        "advanced_example_activity.py",
-        "advanced_example_config.json",
-        "simple_example_activity.py",
-        "simple_example_config.json",
+        "advanced_example.json",
+        "advanced_example.py",
+        "simple_example.py",
+        "simple_example.json",
     ]
     forbid_words = ["template", "example"]
 

--- a/tests/filenames.py
+++ b/tests/filenames.py
@@ -10,8 +10,13 @@ class TestFunctionsInFiles(unittest.TestCase):
     """Test to go through files and use"""
 
     path = "activities/"
-    allow_files = ["activity_template.py", "config_template.json"]
-    forbid_words = ["template"]
+    allow_files = [
+        "advanced_example_activity.py",
+        "advanced_example_config.json",
+        "simple_example_activity.py",
+        "simple_example_config.json",
+    ]
+    forbid_words = ["template", "example"]
 
     def test_filenames(self):
         """Check that files are named properly"""

--- a/tests/json_structure.py
+++ b/tests/json_structure.py
@@ -45,7 +45,7 @@ class TestContentOfJsonFiles(unittest.TestCase):
     """Test to go through files and check internal structure and content"""
 
     path = "activities/"
-    config_template_name = "config_template.json"
+    config_example_names = ["advanced_example.json", "simple_example.json"]
     main_config_file = "config.json"
 
     def test_files_have_expected_content(self):
@@ -131,10 +131,12 @@ class TestContentOfJsonFiles(unittest.TestCase):
                             " which does not exist".format(**locals())
                         )
 
-    @unittest.skip("Too many contributed files with different names at this point")
     def test_python_filename_matches_json(self):
         """Check that filenames match if there is one task in a JSON file"""
         for filename, full_path in get_all_json_files(self.path):
+            if filename == self.main_config_file:
+                # Skip checking the main config file.
+                continue
             with open(full_path) as file_handle:
                 content = json.load(file_handle)
                 tasks = content["tasks"]
@@ -178,12 +180,18 @@ class TestContentOfJsonFiles(unittest.TestCase):
             )
 
     def test_configuration_is_not_from_template(self):
-        with open(os.path.join(self.path, self.config_template_name)) as file_handle:
+        """Check that configuration is different from provided examples or templates"""
+        for example in self.config_example_names:
+            self.configuration_is_not_from_template(example)
+
+    def configuration_is_not_from_template(self, example):
+        """Run comparison for one example or template file"""
+        with open(os.path.join(self.path, example)) as file_handle:
             # assuming we have exactly one task in the template
             template_task = json.load(file_handle)["tasks"][0]
         for filename, full_path in get_all_json_files(self.path):
             # do not check the template itself and main config
-            if filename in (self.config_template_name, self.main_config_file):
+            if filename in (example, self.main_config_file):
                 continue
             with open(full_path) as file_handle:
                 content = json.load(file_handle)
@@ -194,9 +202,9 @@ class TestContentOfJsonFiles(unittest.TestCase):
                         template_task[key],
                         msg=(
                             "Value of {key} in a task in {filename} matches"
-                            " value from the template {self.config_template_name}."
+                            " value from the example file {example}."
                             " {key} value should be different"
-                            " from the template."
+                            " from the provided example."
                             " Change the {key} value in {filename})".format(**locals())
                         ),
                     )
@@ -213,8 +221,8 @@ class TestContentOfJsonFiles(unittest.TestCase):
                     if match_count == len(task["layers"]):
                         self.fail(
                             "Layers in {filename} are identical with"
-                            " the template {self.config_template_name}."
-                            " Layers should be different from the template."
+                            " the example file {example}."
+                            " Layers should be different from the provided example."
                             " Add, remove, or modify the list of layers in {filename}"
                             " to match the output of analysis in {task[analyses]}".format(
                                 **locals()


### PR DESCRIPTION
Use the word example, not a template. Split the example into two, simple and advanced.

Use simpler names which need to be the same for Python and JSON files.
