### PR TITLE
Require instructions and author for each task

### DIFF
--- a/activities/advanced_example.json
+++ b/activities/advanced_example.json
@@ -20,7 +20,9 @@
       },
       "calibrate": true,
       "analyses": "advanced_example.py",
-      "title": "Load and Display Points"
+      "title": "Load and Display Points",
+      "author": "Another Advanced Contributor",
+      "instructions": "Place markers on the landscape and see how they are detected."
     }
   ]
 }

--- a/activities/config.json
+++ b/activities/config.json
@@ -15,7 +15,9 @@
       },
       "calibrate": true,
       "analyses": "simple_example.json",
-      "title": "Template"
+      "title": "Skip This Activity",
+      "author": "Main Contributor",
+      "instructions": "This is just a placeholder because something needs to be in this config."
     }
   ]
 }

--- a/activities/simple_example.json
+++ b/activities/simple_example.json
@@ -13,7 +13,9 @@
         "interpolate": true
       },
       "analyses": "simple_example.py",
-      "title": "Slope and contours"
+      "title": "Slope and Contours",
+      "author": "Example Contributor",
+      "instructions": "Change topography and observe changes in slope and contours."
     }
   ]
 }

--- a/tests/json_structure.py
+++ b/tests/json_structure.py
@@ -46,6 +46,7 @@ class TestContentOfJsonFiles(unittest.TestCase):
 
     path = "activities/"
     config_example_names = ["advanced_example.json", "simple_example.json"]
+    text_items = ["title", "analyses", "author", "instructions"]
     main_config_file = "config.json"
 
     def test_files_have_expected_content(self):
@@ -94,6 +95,25 @@ class TestContentOfJsonFiles(unittest.TestCase):
                             )
                         ),
                     )
+                    for item_key in self.text_items:
+                        self.assertIn(
+                            item_key,
+                            task,
+                            msg=f"task needs to have {item_key} (fix {filename})",
+                        )
+                        item = task[item_key]
+                        self.assertIsInstance(
+                            item,
+                            str,
+                            msg=(
+                                f"{item_key} must be str (string of characters), "
+                                f"not {type(item)} (fix {filename})"
+                            ),
+                        )
+                        self.assertTrue(
+                            item, msg=f"{item_key} must not be empty (fix {filename})"
+                        )
+
                     layers = task["layers"]
                     self.assertIsInstance(
                         layers,
@@ -196,7 +216,7 @@ class TestContentOfJsonFiles(unittest.TestCase):
             with open(full_path) as file_handle:
                 content = json.load(file_handle)
             for task in content["tasks"]:
-                for key in ("title", "analyses"):
+                for key in self.text_items:
                     self.assertNotEqual(
                         task[key],
                         template_task[key],

--- a/website/render_activities.py
+++ b/website/render_activities.py
@@ -103,6 +103,27 @@ def image_to_text(filename):
     return "data:image/png;base64,{0}".format(data)
 
 
+def add_activity(dom, parent, activity, image, heading_level, image_as_data):
+    heading = dom.createElement(heading_level)
+    heading.appendChild(dom.createTextNode(activity["title"]))
+    parent.appendChild(heading)
+    author = dom.createElement("p")
+    emphasis = dom.createElement("em")
+    emphasis.appendChild(dom.createTextNode(f"Created by {activity['author']}."))
+    author.appendChild(emphasis)
+    parent.appendChild(author)
+    description = dom.createElement("p")
+    description.appendChild(dom.createTextNode(activity["instructions"]))
+    parent.appendChild(description)
+    img = dom.createElement("img")
+    if image_as_data:
+        data = image_to_text(image)
+        img.setAttribute("src", data)
+    else:
+        img.setAttribute("src", image)
+    parent.appendChild(img)
+
+
 def create_activity_page(activity, image, filename):
     """Create HTML page for an activity given its definition and redered image"""
     impl = getDOMImplementation()
@@ -117,13 +138,14 @@ def create_activity_page(activity, image, filename):
     title.appendChild(dom.createTextNode(activity["title"]))
     html.appendChild(title)
     body = dom.createElement("body")
-    heading = dom.createElement("h1")
-    heading.appendChild(dom.createTextNode(activity["title"]))
-    body.appendChild(heading)
-    img = dom.createElement("img")
-    data = image_to_text(image)
-    img.setAttribute("src", data)
-    body.appendChild(img)
+    add_activity(
+        dom=dom,
+        parent=body,
+        activity=activity,
+        image=image,
+        heading_level="h1",
+        image_as_data=True,
+    )
     html.appendChild(body)
     with open(filename, mode="w") as out:
         out.write(dom.toxml())
@@ -154,12 +176,14 @@ class IndexPage:
 
     def add_activity(self, activity, image):
         """Add one activity and its image"""
-        heading = self._dom.createElement("h2")
-        heading.appendChild(self._dom.createTextNode(activity["title"]))
-        self._body.appendChild(heading)
-        img = self._dom.createElement("img")
-        img.setAttribute("src", image)
-        self._body.appendChild(img)
+        add_activity(
+            dom=self._dom,
+            parent=self._body,
+            activity=activity,
+            image=image,
+            heading_level="h2",
+            image_as_data=False,
+        )
 
     def finish(self):
         """Finish creating HTML and write it to file"""


### PR DESCRIPTION
A task has now mandatory fields instructions and author. The value of instructions is used together with title in Tangible Landscape
and together with author they are used in the generated HTML pages.
