### PR TITLE
Add full Flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+
+max-line-length = 88
+extend-ignore = E203

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -30,10 +30,8 @@ jobs:
           pip install flake8
       - name: Check code with Flake8
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Check according to the config file.
+          flake8 . --count --show-source --statistics
 
   black:
     name: Black

--- a/tests/json_structure.py
+++ b/tests/json_structure.py
@@ -118,9 +118,7 @@ class TestContentOfJsonFiles(unittest.TestCase):
                     self.assertIsInstance(
                         layers,
                         list,
-                        msg="layers must be a list (of layers), not {provided_type}".format(
-                            provided_type=type(layers)
-                        ),
+                        msg=f"layers must be a list (of layers), not {type(layers)}",
                     )
                     self.assertTrue(
                         layers, msg="layers list must contain at least one item (layer)"
@@ -129,9 +127,7 @@ class TestContentOfJsonFiles(unittest.TestCase):
                         self.assertIsInstance(
                             layer,
                             list,
-                            msg="layer must be a list (a command), not {provided_type}".format(
-                                provided_type=type(layer)
-                            ),
+                            msg=f"layer must be a list (a command), not {type(layer)}",
                         )
                         self.assertTrue(
                             layer,
@@ -169,7 +165,7 @@ class TestContentOfJsonFiles(unittest.TestCase):
                         python_file_no_ext,
                         json_file_no_ext,
                         msg=(
-                            "Python filename {python_file}"
+                            f"Python filename {python_file}"
                             " does not match JSON filename {filename}"
                             " (required for files with only one task)".format(
                                 **locals()
@@ -267,13 +263,11 @@ class TestContentOfJsonFiles(unittest.TestCase):
 
                     if match_count == len(task["layers"]):
                         self.fail(
-                            "Layers in {filename} are identical with"
-                            " the example file {example}."
+                            f"Layers in {filename} are identical with"
+                            f" the example file {example}."
                             " Layers should be different from the provided example."
-                            " Add, remove, or modify the list of layers in {filename}"
-                            " to match the output of analysis in {task[analyses]}".format(
-                                **locals()
-                            )
+                            f" Add, remove, or modify the list of layers in {filename}"
+                            f" to match the output of analysis in {task['analyses']}"
                         )
 
 


### PR DESCRIPTION
The separate Flake8 now does all its checks acording to a new config file.
This avoids the need to search for the error in the Super-Linter output.

Code fixed to comply to 88 chars per line not previosly checked by Flake8 in Super-Linter.
